### PR TITLE
Add argparse

### DIFF
--- a/seestar_run.py
+++ b/seestar_run.py
@@ -177,23 +177,8 @@ def parse_dec_to_float(dec_string):
 is_watch_events = True
 
 
-def main():
-    global HOST
-    global PORT
-    global session_time
-    global s
-    global cmdid
-    global is_watch_events
-    global is_debug
-
-    version_string = "1.0.0b1"
-    print("seestar_run version: ", version_string)
-
-    if len(sys.argv) != 11 and len(sys.argv) != 12:
-        print("expected seestar_run <ip_address> <target_name> <ra> <dec> <is_use_LP_filter> <session_time> <RA panel size> <Dec panel size> <RA offset factor> <Dec offset factor>")
-        sys.exit()
-
-    HOST= sys.argv[1]
+def parse_sys_args():
+    HOST = sys.argv[1]
     target_name = sys.argv[2]
     try:
         center_RA = float(sys.argv[3])
@@ -216,6 +201,28 @@ def main():
     if len(sys.argv) == 12:
         is_debug = sys.argv[11]=="Kai"
 
+    return (HOST, target_name, center_RA, center_Dec, is_use_LP_filter, session_time, nRA, nDec, mRA, mDec, is_debug)
+
+
+def main():
+    global HOST
+    global PORT
+    global session_time
+    global s
+    global cmdid
+    global is_watch_events
+    global is_debug
+
+    version_string = "1.0.0b1"
+    print("seestar_run version: ", version_string)
+
+    if len(sys.argv) != 11 and len(sys.argv) != 12:
+        print("expected seestar_run <ip_address> <target_name> <ra> <dec> <is_use_LP_filter> <session_time> <RA panel size> <Dec panel size> <RA offset factor> <Dec offset factor>")
+        sys.exit()
+
+    is_debug = False
+
+    (HOST, target_name, center_RA, center_Dec, is_use_LP_filter, session_time, nRA, nDec, mRA, mDec, is_ebug) = parse_sys_args()
     print(HOST, target_name, center_RA, center_Dec, is_use_LP_filter, session_time, nRA, nDec, mRA, mDec)
 
     # verify mosaic pattern

--- a/seestar_run.py
+++ b/seestar_run.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime
 import threading
 import sys
+import argparse
 
 
 #I noticed a lot of pairs of test_connection followed by a get if nothing was going on
@@ -225,6 +226,39 @@ def main():
     (HOST, target_name, center_RA, center_Dec, is_use_LP_filter, session_time, nRA, nDec, mRA, mDec, is_ebug) = parse_sys_args()
     print(HOST, target_name, center_RA, center_Dec, is_use_LP_filter, session_time, nRA, nDec, mRA, mDec)
 
+    parser = setup_argparse()
+    args = parser.parse_args()
+
+    # This is going to be messy for now, but I'll clean up the variable references in a future diff.
+    HOST = args.ip
+    target_name = args.title
+    center_RA = args.ra
+    center_Dec = args.dec
+    is_use_LP_filter = args.is_use_LP_filter
+    session_time = args.session_time
+    nRA = args.ra_panel_size
+    nDec = args.dec_panel_size
+    mRA = args.ra_offset_factor
+    mDec = args.dec_offset_factor
+    print(HOST, target_name, center_RA, center_Dec, is_use_LP_filter, session_time, nRA, nDec, mRA, mDec)
+
+    # Preserve old behavior. In the future, I'd like to change this to use the
+    # standard "-v" flag, but that's out of scope for this diff.
+    is_debug = args.is_debug == "Kai"
+
+    try:
+        center_RA = float(center_RA)
+    except ValueError:
+        center_RA = parse_ra_to_float(center_RA)
+
+    try:
+        center_Dec = float(center_Dec)
+    except ValueError:
+        center_Dec = parse_dec_to_float(center_Dec)
+
+
+    print(HOST, target_name, center_RA, center_Dec, is_use_LP_filter, session_time, nRA, nDec, mRA, mDec)
+
     # verify mosaic pattern
     if nRA < 1 or nDec < 0:
         print("Mosaic size is invalid")
@@ -313,6 +347,27 @@ def main():
     is_watch_events = False
     get_msg_thread.join(timeout=5)
     sys.exit()
+
+
+def setup_argparse():
+    # For now, I'm just adding argparse with the bare minimum information. In
+    # the future, we can add descriptive messages here that will make it easier
+    # for users to interact with this script.
+    parser = argparse.ArgumentParser(description='Seestar Run')
+    parser.add_argument('ip', type=str,
+                        help='Your SeeStar\'s IP address')
+    parser.add_argument('title', type=str, help="Observation Target")
+    parser.add_argument('ra', type=str)
+    parser.add_argument('dec', type=str)
+    parser.add_argument('is_use_LP_filter', type=bool)
+    parser.add_argument('session_time', type=int)
+    parser.add_argument('ra_panel_size', type=int)
+    parser.add_argument('dec_panel_size', type=int)
+    parser.add_argument('ra_offset_factor', type=float)
+    parser.add_argument('dec_offset_factor', type=float)
+    parser.add_argument('is_debug', type=str, default=False, nargs='?')
+
+    return parser
 
 
 # seestar_run <ip_address> <target_name> <ra> <dec> <is_use_LP_filter> <session_time> <RA panel size> <Dec panel size> <RA offset factor> <Dec offset factor>


### PR DESCRIPTION
[Argparse](https://docs.python.org/3/library/argparse.html) is a commonly-used Python library for interpreting command-line input for scripts. It has a couple of advantages over trying to parse input manually by pulling from `sys.argv` - notably, it's less brittle (can reorganize, rename, add, or remove parameters more easily), it has built-in input validation, and you can add contextual help messages to make it easier for users to understand how to use your script.

In this PR, I'm moving the `sys.argv` parsing out of main and into its own function, and then printing out the results of both `sys.argv` and `argparse` so that the user can compare. So far, I think they're identical, so I plan to remove the sys.argv parsing in my next diff, but I think this is a good middle ground so that anyone else using this script can easily verify the behavior for themselves.